### PR TITLE
cmd/root: Always run `ostree admin finalize-staged`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -133,6 +133,11 @@ func Execute(cmd *cobra.Command, args []string) {
 		"--custom-origin-url", customURL,
 		"--custom-origin-description", "Managed by pivot tool")
 
+	// We do this here to take that cost upfront and potentially fail on any
+	// errors right away instead of having the MCD figure it out on its own
+	// after the reboot.
+	utils.Run("ostree", "admin", "finalize-staged")
+
 	// Kill our dummy container
 	podmanRemove(types.PivotName)
 


### PR DESCRIPTION
In the context in which `pivot` is called, we want to do as much work as
possible upfront so that we (1) minimize downtime, and (2) fail early.

From https://github.com/openshift/machine-config-operator/pull/245#discussion_r242947874.