### PR TITLE
Add pivot.service as a host API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ pivot
 *.out
 # editor
 .vscode
+
+systemd/pivot.service

--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ Though normally, one wants to use digests rather than tags, e.g.:
 pivot -r $REGISTRY/os@sha256:fdf70521df4ed1dc135d81fd3c4608574aeca45dc22d1b4e38d16630e9d6f1a7
 ```
 
+It also comes with a systemd unit to provide a "host API". For example:
+
+```
+mkdir -p /etc/pivot
+echo $REGISTRY/os:latest > /etc/pivot/image-pullspec
+touch /run/pivot-reboot-needed
+systemctl start pivot
+```
+
+This will start `pivot`, which will read the file and execute the pivot.
+If the pivot is completed, the file will be deleted. The expected way to
+make use of this is to create the necessary files from Ignition.
+
 See
 ---
 - [openshift/os](https://github.com/openshift/os/)

--- a/pivot.spec
+++ b/pivot.spec
@@ -1,8 +1,8 @@
 %define debug_package %{nil}
 
 Name:           pivot
-Version:        0.0.2
-Release:        0.1%{?dist}
+Version:        0.0.3
+Release:        1%{?dist}
 Summary:        allows moving from one OSTree deployment to another
 
 License:        ASL 2.0
@@ -21,7 +21,7 @@ deployment to another with minimal effort.
 %prep
 %autosetup -n %{name}-%{version}
 mkdir -p src/github.com/openshift/%{name}/
-cp -rf cmd  Gopkg.lock  Gopkg.toml  LICENSE  main.go  Makefile  pivot.spec  README.md  types  utils vendor VERSION src/github.com/openshift/%{name}
+cp -rf cmd  Gopkg.lock  Gopkg.toml  LICENSE  main.go  Makefile  pivot.spec  README.md  types  utils vendor VERSION systemd src/github.com/openshift/%{name}
 
 %build
 export GOPATH=`pwd`
@@ -36,9 +36,12 @@ make install DESTDIR=%{buildroot}
 %license LICENSE
 %doc README.md
 %{_bindir}/%{name}
-
+%{_prefix}/lib/systemd/system/pivot.*
 
 %changelog
+* Tue Feb 05 2019 Jonathan Lebon <jlebon@redhat.com> - 0.0.3-1
+- Add systemd service unit
+
 * Wed Nov 14 2018 Steve Milner <smilner@redhat.com> - 0.0.2-0.1
 - Makefile: Add changelog target
 - cmd/root: Print pivoting msg before pull

--- a/systemd/pivot.service.in
+++ b/systemd/pivot.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Pivot Tool
+ConditionPathExists=/etc/pivot/image-pullspec
+After=ignition-firstboot-complete.service
+Before=kubelet.service
+
+[Service]
+Type=simple
+ExecStart=@@PIVOT_BINARY_PATH@@
+
+[Install]
+WantedBy=multi-user.target

--- a/utils/fs.go
+++ b/utils/fs.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"os"
+
+	"github.com/golang/glog"
+)
+
+// FileExists checks if the file exists, gracefully handling ENOENT.
+func FileExists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+		glog.Fatalf("Failed to stat %s: %v", path, err)
+	}
+	return true
+}


### PR DESCRIPTION
Add a new systemd service that simply executes `pivot`. But note that we
don't have a `pivot.path` unit to auto-trigger it: this needs to be
triggered explicitly by whatever drives pivot. Making it a service and
standizing on a path in `/etc` means that we can trigger a pivot on boot
from Ignition (patch to preset enable the service is pending), as well
as from the MCD by directly starting the unit.

By running it directly from the host context rather than e.g. directly
by the MCD, we also avoid potential issues with SELinux as described in:
openshift/machine-config-operator#314