### PR TITLE
tests: Set GOCACHE=off

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,4 +64,4 @@ lint:
 
 
 test:
-	go list ./... | grep -v vendor | xargs go test -v
+	go list ./... | grep -v vendor | xargs env GOCACHE=off go test -v


### PR DESCRIPTION
Follow in the footsteps of the MCO here:
https://github.com/openshift/machine-config-operator/pull/391

I definitely hit this in the past and couldn't understand why it wasn't
rerunning the tests, but didn't bother to look deeper into it.