### PR TITLE
service: Use Type=oneshot

### DIFF
--- a/systemd/pivot.service.in
+++ b/systemd/pivot.service.in
@@ -5,7 +5,8 @@ After=ignition-firstboot-complete.service
 Before=kubelet.service
 
 [Service]
-Type=simple
+# Need oneshot to delay kubelet
+Type=oneshot
 ExecStart=@@PIVOT_BINARY_PATH@@
 
 [Install]


### PR DESCRIPTION
Today we have `Before=kubelet.service`, the intention here
is we support upgrading before the node joins the cluster.  But
in fact today we race because we really want `Type=oneshot` to
delay execution of other units until we're done.