### PR TITLE
Add basic kernel tuning functionality

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -28,5 +30,113 @@ func TestCompareOSImageURL(t *testing.T) {
 	m, err := compareOSImageURL(refA, "registry.example.com/foo/bar")
 	if m || err == nil {
 		t.Fatalf("Expected err")
+	}
+}
+
+// writeTestFile writes out a file to use in the test
+func writeTestFile(content []byte) (filePath string, err error) {
+	tmpfile, err := ioutil.TempFile("", "testFile")
+	if err != nil {
+		return "", err
+	}
+	filePath = tmpfile.Name()
+	if _, err := tmpfile.Write(content); err != nil {
+		return filePath, err
+	}
+	if err := tmpfile.Close(); err != nil {
+		return filePath, err
+	}
+	return filePath, nil
+}
+
+func TestParseTuningFile(t *testing.T) {
+	cmdLineFileMock, err := writeTestFile([]byte(
+		"BOOT_IMAGE=/a/vmlinuz.x86_64 resume=/dev/mapper/swap rhgb quiet root=/a/b/c/root ostree=/ostree/boot.0/a/0"))
+	defer os.Remove(cmdLineFileMock)
+
+	// Test with addition/deletion and verify white list
+	testFilePath, err := writeTestFile([]byte("ADD nosmt\nADD aaaa\nDELETE nosmt\nDELETE nope"))
+	defer os.Remove(testFilePath)
+	if err != nil {
+		t.Fatalf("unable to write test file %s: %s", testFilePath, err)
+	}
+	add, delete, err := parseTuningFile(testFilePath, cmdLineFileMock)
+	if err != nil {
+		t.Fatalf(`Expected no error, got %s`, err)
+	}
+	if len(add) != 1 {
+		t.Fatalf("Expected 1 addition, got %v", len(add))
+	}
+
+	if len(delete) != 0 {
+		t.Fatalf("Expected 0 deletion, got %v", len(delete))
+	}
+
+	deleteCmdLineFileMockWith, err := writeTestFile([]byte(
+		"BOOT_IMAGE=/a/vmlinuz.x86_64 nosmt resume=/dev/mapper/swap rhgb quiet root=/a/b/c/root ostree=/ostree/boot.0/a/0"))
+	defer os.Remove(deleteCmdLineFileMockWith)
+
+	// Test with addition/deletion and verify white list
+	testFilePath, err = writeTestFile([]byte("ADD nosmt\nADD aaaa\nDELETE nosmt\nDELETE nope"))
+	defer os.Remove(testFilePath)
+	if err != nil {
+		t.Fatalf("unable to write test file %s: %s", testFilePath, err)
+	}
+	add, delete, err = parseTuningFile(testFilePath, deleteCmdLineFileMockWith)
+	if err != nil {
+		t.Fatalf(`Expected no error, got %s`, err)
+	}
+	if len(add) != 0 {
+		t.Fatalf("Expected 1 addition, got %v", len(add))
+	}
+
+	if len(delete) != 1 {
+		t.Fatalf("Expected 1 deletion, got %v", len(delete))
+	}
+
+	// Test with no changes
+	testFilePath, err = writeTestFile([]byte(""))
+	defer os.Remove(testFilePath)
+	if err != nil {
+		t.Fatalf("unable to write test file %s: %s", testFilePath, err)
+	}
+	add, delete, err = parseTuningFile(testFilePath, cmdLineFileMock)
+	if err != nil {
+		t.Fatalf(`Expected no error, got %s`, err)
+	}
+
+	if len(add) != 0 {
+		t.Fatalf("Expected 0 addition, got %v", len(add))
+	}
+
+	if len(delete) != 0 {
+		t.Fatalf("Expected 0 deletion, got %v", len(add))
+	}
+}
+
+func TestIsArgInUse(t *testing.T) {
+	testFilePath, err := writeTestFile([]byte(
+		"BOOT_IMAGE=/a/vmlinuz.x86_64 resume=/dev/mapper/swap rhgb quiet root=/a/b/c/root ostree=/ostree/boot.0/a/0"))
+	if err != nil {
+		t.Fatalf("unable to write test file %s: %s", testFilePath, err)
+	}
+	defer os.Remove(testFilePath)
+
+	// Should be present
+	available, err := isArgInUse("quiet", testFilePath)
+	if err != nil {
+		t.Fatalf(`Expected no error, got %s`, err)
+	}
+	if available != true {
+		t.Fatalf("Expected true, got false")
+	}
+
+	// Should not be present
+	available, err = isArgInUse("idonotexist", testFilePath)
+	if err != nil {
+		t.Fatalf(`Expected no error, got %s`, err)
+	}
+	if available != false {
+		t.Fatalf("Expected false, got true")
 	}
 }

--- a/types/tuneargument.go
+++ b/types/tuneargument.go
@@ -1,0 +1,8 @@
+package types
+
+// TuneArgument represents a single tuning argument
+type TuneArgument struct {
+	Key   string `json:"key"`   // The name of the argument (or argument itself if Bare)
+	Value string `json:"value"` // The value of the argument
+	Bare  bool   `json:"bare"`  // If the kernel argument is a bare argument (no value expected)
+}


### PR DESCRIPTION
Checks `/etc/pivot/kernel-args` for argument changes. This early version only supports bare arguments that are in the whitelist.

See conversation at https://github.com/openshift/machine-config-operator/pull/576

Requires: https://github.com/projectatomic/rpm-ostree/pull/1796