### PR TITLE
 Use `podman pull -q`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -289,7 +289,7 @@ func pullAndRebase(container string) (imgid string, changed bool) {
 	}
 
 	// Pull the image
-	podmanArgs := []string{"pull"}
+	podmanArgs := []string{"pull", "-q"}
 	podmanArgs = append(podmanArgs, authArgs...)
 	podmanArgs = append(podmanArgs, imgid)
 	utils.RunExt(false, numRetriesNetCommands, "podman", podmanArgs...)


### PR DESCRIPTION

Otherwise it uses non-Unicode terminal escape codes, which causes
journald to emit a useless spam of:

```
Apr 04 18:33:20 osiris-f5ns8-master-0 pivot[1049]: [54B blob data]
Apr 04 18:33:20 osiris-f5ns8-master-0 pivot[1049]: [54B blob data]
Apr 04 18:33:20 osiris-f5ns8-master-0 pivot[1049]: [54B blob data]
Apr 04 18:33:20 osiris-f5ns8-master-0 pivot[1049]: [54B blob data]
Apr 04 18:33:21 osiris-f5ns8-master-0 pivot[1049]: [54B blob data]
Apr 04 18:33:21 osiris-f5ns8-master-0 pivot[1049]: [54B blob data]
```

Ideally podman would detect if the output is journald and not
use terminal codes or so, but for now let's just quiet it.