### PR TITLE
Don't use `skopeo inspect` for canonical (digested) pull specs

### DIFF
--- a/types/imageinspection.go
+++ b/types/imageinspection.go
@@ -17,7 +17,7 @@ type ImageInspection struct {
 	Name          string `json:",omitempty"`
 	Tag           string `json:",omitempty"`
 	Digest        digest.Digest
-	RepoTags      []string
+	RepoDigests   []string
 	Created       *time.Time
 	DockerVersion string
 	Labels        map[string]string


### PR DESCRIPTION
`skopeo inspect` hits the `/tags` API which can be expensive
for registries to compute.  Quay.io recently changed how
they do rate limiting, and we started hitting this in OpenShift CI
jobs.

Since the machine-config-operator always provides canonical/digested
pull specs, the non-digested support is just for local developer
convenience.

And anyways, what we really should do is pull the image unconditionally
and then inspect it afterwards, we don't need all of the tag info.

Basically this PR ends up in a place where the non-canonical
path only loses out on the optimization of avoiding pulling the
image in the case where we already have that target.