### PR TITLE
Remove GOCACHE=off for testing and test on 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - "1.10.x"
   - "1.11.x"
+  - "1.12.x"
   - tip
 
 matrix:

--- a/Makefile
+++ b/Makefile
@@ -64,4 +64,4 @@ lint:
 
 
 test:
-	go list ./... | grep -v vendor | xargs env GOCACHE=off go test -v
+	go list ./... | grep -v vendor | xargs go test -v


### PR DESCRIPTION
The following error occurs with Go 1.12+:
```
  build cache is disabled by GOCACHE=off, but required as of Go 1.12
  make: *** [Makefile:67: test] Error 123
```
This commit removes `GOCACHE=off` allowing unit testing to proceed. It also bumps up travis testing to use 1.11.x and 1.12.x.