### PR TITLE
utils: fix FileExists

### DIFF
--- a/utils/fs.go
+++ b/utils/fs.go
@@ -8,11 +8,9 @@ import (
 
 // FileExists checks if the file exists, gracefully handling ENOENT.
 func FileExists(path string) bool {
-	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
-			return false
-		}
-		glog.Fatalf("Failed to stat %s: %v", path, err)
+	if _, err := os.Stat(path); err == nil {
+		return true
 	}
-	return true
+	glog.Warningf("Failed to stat %s: %v", path, err)
+	return false
 }


### PR DESCRIPTION
It still not 100% clear what's happening with https://bugzilla.redhat.com/show_bug.cgi?id=1723327 but I've spotted `pivot` rebooting the system in a normal MCD sync (not early pivot).

```
...
Jun 23 12:01:19 dell0 pivot[30574]: I0623 12:01:19.133841   30574 run.go:16] Running: systemctl reboot
...
```

It could be something else, but FileExists shouldn't return `true` if there are errors, for instance, that prevents reading the file altogether.

EDIT: it might be something else though, or otherwise we would have gotten this log https://github.com/openshift/pivot/pull/57/files#diff-c15a259ec4bacb664668794acd70456fL15

cc @cgwalters @jlebon @ashcrow (this would be for 4.1 as the upgrade failure is happening there)